### PR TITLE
Create retro Windows 95-style projects desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# test
+# Retro Project Workstation
+
+Static retro-inspired desktop that emulates a Windows 95 boot-up sequence with interactive windows for showcasing projects.
+
+## Getting started
+
+Open `index.html` in a modern browser to experience the boot animation and explore the simulated desktop environment. All interactions run entirely in the browser, so no build step is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Project Workstation</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="boot-screen" role="presentation">
+      <div class="boot-screen__overlay">
+        <div class="boot-screen__logo">AMERICAN MEGATRENDS</div>
+        <div class="boot-screen__log" aria-live="polite"></div>
+        <div class="boot-screen__progress">
+          <div class="boot-screen__progress-bar"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="desktop" aria-label="Windows 95 inspired workspace" hidden>
+      <div class="desktop__icons" role="list">
+        <button type="button" class="desktop-icon" data-window="system-window" role="listitem">
+          <span class="desktop-icon__image icon icon--computer" aria-hidden="true"></span>
+          <span class="desktop-icon__label">My Computer</span>
+        </button>
+        <button type="button" class="desktop-icon" data-window="projects-window" role="listitem">
+          <span class="desktop-icon__image icon icon--folder" aria-hidden="true"></span>
+          <span class="desktop-icon__label">Projects</span>
+        </button>
+        <button type="button" class="desktop-icon" data-window="bin-window" role="listitem">
+          <span class="desktop-icon__image icon icon--bin" aria-hidden="true"></span>
+          <span class="desktop-icon__label">Recycle Bin</span>
+        </button>
+      </div>
+
+      <div class="window" id="system-window" role="dialog" aria-modal="false" aria-labelledby="system-window-title">
+        <div class="window__titlebar" data-draggable="true">
+          <div class="window__title">
+            <span class="window__icon icon icon--computer" aria-hidden="true"></span>
+            <span id="system-window-title">System Properties</span>
+          </div>
+          <div class="window__controls">
+            <button type="button" class="window__btn window__btn--min" data-action="minimize" aria-label="Minimize window">&#95;</button>
+            <button type="button" class="window__btn window__btn--max" data-action="maximize" aria-label="Maximize window">&#9633;</button>
+            <button type="button" class="window__btn window__btn--close" data-action="close" aria-label="Close window">&#10005;</button>
+          </div>
+        </div>
+        <div class="window__content">
+          <section class="window__group">
+            <h2 class="window__heading">System Check</h2>
+            <ul class="bios-list">
+              <li>CPU Detected: Pentium&reg; Pro 200 MHz</li>
+              <li>Memory Test: 131072K OK</li>
+              <li>L2 Cache: 512K Enabled</li>
+              <li>Video BIOS: VGA Compatible</li>
+            </ul>
+          </section>
+          <section class="window__group">
+            <h2 class="window__heading">Drives</h2>
+            <ul class="bios-list">
+              <li>Primary Master: Quantum Fireball 4.3GB</li>
+              <li>Primary Slave: None</li>
+              <li>Secondary Master: ATAPI CD-ROM</li>
+              <li>Secondary Slave: 1.44MB 3&#189;" Floppy</li>
+            </ul>
+          </section>
+        </div>
+      </div>
+
+      <div class="window" id="projects-window" role="dialog" aria-modal="false" aria-labelledby="projects-window-title">
+        <div class="window__titlebar" data-draggable="true">
+          <div class="window__title">
+            <span class="window__icon icon icon--folder" aria-hidden="true"></span>
+            <span id="projects-window-title">Projects</span>
+          </div>
+          <div class="window__controls">
+            <button type="button" class="window__btn window__btn--min" data-action="minimize" aria-label="Minimize window">&#95;</button>
+            <button type="button" class="window__btn window__btn--max" data-action="maximize" aria-label="Maximize window">&#9633;</button>
+            <button type="button" class="window__btn window__btn--close" data-action="close" aria-label="Close window">&#10005;</button>
+          </div>
+        </div>
+        <div class="window__content window__content--projects">
+          <div class="projects-intro">
+            <p class="projects-intro__lead">Projects directory</p>
+            <p class="projects-intro__text">Nothing found.. :(</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="window" id="bin-window" role="dialog" aria-modal="false" aria-labelledby="bin-window-title">
+        <div class="window__titlebar" data-draggable="true">
+          <div class="window__title">
+            <span class="window__icon icon icon--bin" aria-hidden="true"></span>
+            <span id="bin-window-title">Recycle Bin</span>
+          </div>
+          <div class="window__controls">
+            <button type="button" class="window__btn window__btn--min" data-action="minimize" aria-label="Minimize window">&#95;</button>
+            <button type="button" class="window__btn window__btn--max" data-action="maximize" aria-label="Maximize window">&#9633;</button>
+            <button type="button" class="window__btn window__btn--close" data-action="close" aria-label="Close window">&#10005;</button>
+          </div>
+        </div>
+        <div class="window__content">
+          <p>The recycle bin is empty.</p>
+        </div>
+      </div>
+
+      <footer class="taskbar" role="toolbar" aria-label="Taskbar">
+        <button class="taskbar__start">
+          <span class="taskbar__start-icon">&#10066;</span>
+          <span>Start</span>
+        </button>
+        <div class="taskbar__tray" aria-live="polite"></div>
+        <div class="taskbar__clock" aria-live="polite"></div>
+      </footer>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,253 @@
+const bootScreen = document.querySelector('.boot-screen');
+const bootLog = document.querySelector('.boot-screen__log');
+const bootProgressBar = document.querySelector('.boot-screen__progress-bar');
+const desktop = document.querySelector('.desktop');
+const icons = document.querySelectorAll('.desktop-icon');
+const windows = document.querySelectorAll('.window');
+const taskbarTray = document.querySelector('.taskbar__tray');
+const taskbarClock = document.querySelector('.taskbar__clock');
+
+let highestZ = 20;
+const taskButtonMap = new Map();
+
+const bootLines = [
+  'American Megatrends BIOS v1.43',
+  'Copyright (C) 1994-1996 American Megatrends, Inc.',
+  'BIOS Date: 09/01/95 16:06:41  Ver: 1.00.09.DF0',
+  'CPU: Pentium(R) Pro 200MHz',
+  'Memory Test: 131072K OK',
+  'Keyboard... Detected',
+  'Mouse.... PS/2 Compatible',
+  'Initializing Plug and Play Cards...',
+  'Primary Master: QUANTUM FIREBALL 4.3A',
+  'Primary Slave : -- None --',
+  'Secondary Master: ATAPI CD-ROM 24X',
+  'Secondary Slave : 1.44MB 3½" Floppy',
+  'Detecting IDE Devices...',
+  'Auto-Detecting Fixed Disk...',
+  'Auto-Detecting ATAPI Devices...',
+  'Verifying DMI Pool Data...',
+  'Starting Windows 95...'
+];
+
+function simulateBoot() {
+  let index = 0;
+  const total = bootLines.length;
+
+  const interval = setInterval(() => {
+    const line = bootLines[index];
+    if (line) {
+      bootLog.textContent += `${line}\n`;
+      bootProgressBar.style.width = `${Math.round(((index + 1) / total) * 100)}%`;
+    }
+
+    index += 1;
+    if (index >= total) {
+      clearInterval(interval);
+      setTimeout(() => {
+        bootScreen.setAttribute('hidden', '');
+        desktop.hidden = false;
+        openWindow(document.getElementById('projects-window'));
+      }, 1200);
+    }
+  }, 420);
+}
+
+function bringToFront(win) {
+  highestZ += 1;
+  win.style.zIndex = highestZ;
+  windows.forEach((w) => w.classList.toggle('is-active', w === win && !w.classList.contains('window--hidden')));
+  taskButtonMap.forEach((button, id) => {
+    if (id === win.id && !win.classList.contains('window--hidden')) {
+      button.classList.add('is-active');
+    } else {
+      button.classList.remove('is-active');
+    }
+  });
+}
+
+function ensureTaskButton(win) {
+  let button = taskButtonMap.get(win.id);
+  if (!button) {
+    button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'taskbar__button';
+    button.textContent = win.querySelector('.window__title span:last-child').textContent;
+    button.addEventListener('click', () => {
+      if (win.classList.contains('window--hidden')) {
+        showWindow(win);
+      } else {
+        minimizeWindow(win);
+      }
+    });
+    taskbarTray.appendChild(button);
+    taskButtonMap.set(win.id, button);
+  }
+  return button;
+}
+
+function showWindow(win) {
+  restorePreviousPosition(win);
+  win.classList.add('is-active');
+  win.classList.remove('window--hidden');
+  win.style.display = 'flex';
+  ensureTaskButton(win).classList.add('is-active');
+  bringToFront(win);
+}
+
+function hideWindow(win) {
+  win.classList.remove('is-active');
+  win.style.display = 'none';
+  const button = taskButtonMap.get(win.id);
+  if (button) {
+    button.classList.remove('is-active');
+  }
+}
+
+function minimizeWindow(win) {
+  win.classList.add('window--hidden');
+  win.classList.remove('is-active');
+  const button = ensureTaskButton(win);
+  button.classList.remove('is-active');
+}
+
+function closeWindow(win) {
+  restorePreviousPosition(win);
+  win.classList.add('window--hidden');
+  win.classList.remove('is-active');
+  win.style.display = 'none';
+  const button = taskButtonMap.get(win.id);
+  if (button) {
+    button.remove();
+    taskButtonMap.delete(win.id);
+  }
+}
+
+function toggleMaximize(win) {
+  if (win.classList.contains('window--maximized')) {
+    restorePreviousPosition(win);
+  } else {
+    win.dataset.previousPosition = JSON.stringify({
+      left: win.style.left || `${win.offsetLeft}px`,
+      top: win.style.top || `${win.offsetTop}px`,
+      width: win.style.width || `${win.offsetWidth}px`,
+      height: win.style.height || `${win.offsetHeight}px`
+    });
+    win.classList.add('window--maximized');
+    win.style.width = '100%';
+    win.style.height = `calc(100% - 4.5rem)`;
+    win.style.left = '0';
+    win.style.top = '2.5rem';
+  }
+  bringToFront(win);
+}
+
+function openWindow(win) {
+  if (!win) return;
+  showWindow(win);
+}
+
+function restorePreviousPosition(win) {
+  if (!win.classList.contains('window--maximized')) return;
+  win.classList.remove('window--maximized');
+  const previous = win.dataset.previousPosition;
+  if (previous) {
+    const { left, top, width, height } = JSON.parse(previous);
+    win.style.left = left;
+    win.style.top = top;
+    win.style.width = width;
+    win.style.height = height;
+    delete win.dataset.previousPosition;
+  }
+}
+
+icons.forEach((icon) => {
+  icon.addEventListener('dblclick', () => {
+    const win = document.getElementById(icon.dataset.window);
+    openWindow(win);
+  });
+
+  icon.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      const win = document.getElementById(icon.dataset.window);
+      openWindow(win);
+    }
+  });
+});
+
+windows.forEach((win) => {
+  const titlebar = win.querySelector('.window__titlebar');
+  titlebar.addEventListener('dblclick', () => toggleMaximize(win));
+
+  win.addEventListener('mousedown', () => bringToFront(win));
+
+  win.querySelectorAll('.window__btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.action;
+      if (action === 'minimize') {
+        minimizeWindow(win);
+      } else if (action === 'maximize') {
+        toggleMaximize(win);
+      } else if (action === 'close') {
+        closeWindow(win);
+      }
+    });
+  });
+});
+
+let isDragging = false;
+let dragTarget = null;
+let dragOffsetX = 0;
+let dragOffsetY = 0;
+
+function startDrag(event, win) {
+  if (win.classList.contains('window--maximized')) return;
+  isDragging = true;
+  dragTarget = win;
+  const rect = win.getBoundingClientRect();
+  dragOffsetX = event.clientX - rect.left;
+  dragOffsetY = event.clientY - rect.top;
+  win.style.position = 'absolute';
+  bringToFront(win);
+}
+
+function onPointerMove(event) {
+  if (!isDragging || !dragTarget) return;
+  const desktopRect = desktop.getBoundingClientRect();
+  const newLeft = event.clientX - dragOffsetX - desktopRect.left;
+  const newTop = event.clientY - dragOffsetY - desktopRect.top;
+  dragTarget.style.left = `${Math.max(0, newLeft)}px`;
+  dragTarget.style.top = `${Math.max(0, newTop)}px`;
+}
+
+function stopDrag() {
+  isDragging = false;
+  dragTarget = null;
+}
+
+desktop.addEventListener('pointerdown', (event) => {
+  if (event.target.closest('.window__btn')) return;
+  const titlebar = event.target.closest('.window__titlebar');
+  if (titlebar) {
+    const win = titlebar.closest('.window');
+    startDrag(event, win);
+  }
+});
+
+desktop.addEventListener('pointermove', onPointerMove);
+desktop.addEventListener('pointerup', stopDrag);
+desktop.addEventListener('pointercancel', stopDrag);
+window.addEventListener('pointerup', stopDrag);
+window.addEventListener('pointermove', onPointerMove);
+
+function updateClock() {
+  const now = new Date();
+  const hours = now.getHours().toString().padStart(2, '0');
+  const minutes = now.getMinutes().toString().padStart(2, '0');
+  taskbarClock.textContent = `${hours}:${minutes}`;
+}
+
+setInterval(updateClock, 30000);
+updateClock();
+
+simulateBoot();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,409 @@
+:root {
+  --surface: #c3c7cb;
+  --surface-light: #ffffff;
+  --surface-dark: #808080;
+  --surface-darker: #404040;
+  --text-primary: #000000;
+  --text-inverse: #f0f0f0;
+  --accent: #000080;
+  --accent-light: #1084d0;
+  --desktop: #008080;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Perfect DOS VGA 437", "Lucida Console", "Courier New", monospace;
+  background-color: #000;
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+}
+
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  color: #f22;
+  display: grid;
+  place-items: center;
+  z-index: 999;
+  font-size: 1rem;
+}
+
+.boot-screen__overlay {
+  width: min(600px, 90vw);
+  padding: 1.5rem 1.75rem 1.75rem;
+  border: 2px solid #444;
+  background: #000;
+  box-shadow: 0 0 0 2px #111;
+}
+
+.boot-screen__logo {
+  font-size: 1.2rem;
+  letter-spacing: 0.5rem;
+  margin-bottom: 1rem;
+  color: #f22;
+}
+
+.boot-screen__log {
+  min-height: 16rem;
+  white-space: pre-line;
+  line-height: 1.35;
+  color: #ccc;
+  font-family: "IBM Plex Mono", "Lucida Console", "Courier New", monospace;
+}
+
+.boot-screen__progress {
+  margin-top: 1.5rem;
+  height: 1.25rem;
+  border: 2px inset #888;
+  background: #111;
+}
+
+.boot-screen__progress-bar {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #0f0 0%, #0a0 60%, #070 100%);
+  transition: width 0.4s linear;
+}
+
+.boot-screen[hidden] {
+  display: none;
+}
+
+.desktop {
+  position: relative;
+  min-height: 100vh;
+  background: var(--desktop);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.desktop__icons {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  gap: 1.5rem 2rem;
+  padding: 2rem;
+  width: min(100%, 900px);
+}
+
+.desktop-icon {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: #fff;
+  text-shadow: 1px 1px #000;
+}
+
+.desktop-icon:focus-visible,
+.desktop-icon:hover {
+  border-color: #fff;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.desktop-icon__label {
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.icon {
+  display: inline-block;
+  width: 42px;
+  height: 42px;
+  image-rendering: pixelated;
+}
+
+.icon--folder {
+  background:
+    linear-gradient(#ffe08b 0 50%, #ffc24b 50% 100%);
+  border: 2px solid #8b6508;
+  box-shadow: inset -3px -3px 0 0 rgba(0, 0, 0, 0.25);
+  position: relative;
+}
+
+.icon--folder::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: -2px;
+  width: 26px;
+  height: 12px;
+  background: #ffe8aa;
+  border: 2px solid #8b6508;
+  border-bottom: none;
+}
+
+.icon--computer {
+  position: relative;
+  border: 2px solid #3f3f3f;
+  background: linear-gradient(#d8dbe2, #a6acbb);
+}
+
+.icon--computer::before,
+.icon--computer::after {
+  content: "";
+  position: absolute;
+}
+
+.icon--computer::before {
+  inset: 6px 6px 16px 6px;
+  background: #00008b;
+  border: 2px inset #000;
+}
+
+.icon--computer::after {
+  height: 10px;
+  width: 20px;
+  bottom: 4px;
+  left: 10px;
+  border: 2px solid #3f3f3f;
+  background: #cfd4db;
+}
+
+.icon--bin {
+  position: relative;
+  border: 2px solid #4c4c4c;
+  background: linear-gradient(#d7f6ff, #a0d7f2);
+}
+
+.icon--bin::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 2px dotted #4c4c4c;
+}
+
+.window {
+  position: absolute;
+  top: 6rem;
+  left: 4rem;
+  width: 22rem;
+  background: var(--surface);
+  border: 2px solid var(--surface-dark);
+  box-shadow: 4px 4px 0 #000;
+  display: none;
+  flex-direction: column;
+  z-index: 10;
+}
+
+#system-window {
+  top: 5rem;
+  left: 5rem;
+}
+
+#projects-window {
+  top: 9rem;
+  left: 16rem;
+}
+
+#bin-window {
+  top: 13rem;
+  left: 24rem;
+}
+
+.window.is-active {
+  display: flex;
+}
+
+.window__titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  background: linear-gradient(var(--accent-light), var(--accent));
+  color: var(--text-inverse);
+  user-select: none;
+  cursor: move;
+}
+
+.window__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: bold;
+  letter-spacing: 0.05rem;
+}
+
+.window__icon {
+  width: 22px;
+  height: 22px;
+  transform: scale(0.9);
+  filter: saturate(0.9);
+}
+
+.window__controls {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.window__btn {
+  width: 1.5rem;
+  height: 1.5rem;
+  background: var(--surface-light);
+  border: 2px outset var(--surface-light);
+  color: #000;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.window__btn:active {
+  border-style: inset;
+}
+
+.window__content {
+  padding: 1rem;
+  background: var(--surface-light);
+  color: #000;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.window__group + .window__group {
+  margin-top: 1rem;
+}
+
+.window__heading {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  border-bottom: 2px groove var(--surface-dark);
+  padding-bottom: 0.25rem;
+}
+
+.bios-list {
+  list-style: square;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.window__content--projects {
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.projects-intro {
+  border: 2px inset var(--surface-dark);
+  padding: 1.5rem;
+  background: #f9f9f9;
+  box-shadow: inset -4px -4px 0 rgba(0, 0, 0, 0.2);
+}
+
+.projects-intro__lead {
+  margin: 0 0 0.75rem;
+  font-weight: bold;
+}
+
+.projects-intro__text {
+  margin: 0;
+  color: #333;
+}
+
+.window--hidden {
+  display: none !important;
+}
+
+.window--maximized {
+  top: 2.5rem !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: calc(100% - 4.5rem) !important;
+}
+
+.taskbar {
+  margin-top: auto;
+  height: 2.5rem;
+  background: #c0c0c0;
+  border-top: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.5rem;
+  box-shadow: inset 0 2px #fff;
+}
+
+.taskbar__start {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: #c0c0c0;
+  border: 2px outset #fff;
+  font-weight: bold;
+}
+
+.taskbar__start:active {
+  border-style: inset;
+}
+
+.taskbar__start-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.taskbar__tray {
+  display: flex;
+  gap: 0.25rem;
+  flex: 1;
+  height: 1.75rem;
+  align-items: center;
+}
+
+.taskbar__button {
+  min-width: 8rem;
+  padding: 0.25rem 0.5rem;
+  background: #dcdcdc;
+  border: 2px outset #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.taskbar__button.is-active {
+  border-style: inset;
+  background: #b0b0b0;
+}
+
+.taskbar__clock {
+  min-width: 5rem;
+  text-align: center;
+  padding: 0.25rem 0.5rem;
+  border: 2px inset #fff;
+  background: #dcdcdc;
+  font-size: 0.85rem;
+}
+
+.window__content p {
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .desktop__icons {
+    grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
+    gap: 1rem 1.5rem;
+    padding: 1rem;
+  }
+
+  .window {
+    width: min(90vw, 24rem);
+    left: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a BIOS-inspired boot screen that transitions into a Windows 95-style desktop experience
- implement draggable, minimizable, maximizable, and closable windows with taskbar integration for desktop icons
- style the interface with pixel art icons, taskbar, and updated README instructions to match the retro theme

## Testing
- Not run (static HTML/CSS/JS project)


------
https://chatgpt.com/codex/tasks/task_e_68cc4ef36f3c832b9daf822e8743053b