### PR TITLE
Add immersive parallax background demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dreamwave Parallax</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="parallax" id="parallax">
+      <div class="layer layer--back" data-depth="0.18"></div>
+      <div class="layer layer--mid" data-depth="0.32"></div>
+      <div class="layer layer--front" data-depth="0.48"></div>
+      <div class="layer particles" data-depth="0.62" id="particles"></div>
+      <canvas class="aurora" id="aurora" data-depth="0.12"></canvas>
+    </div>
+
+    <main class="hero">
+      <header class="hero__content">
+        <p class="hero__eyebrow">Новый уровень фона</p>
+        <h1 class="hero__title">Dreamwave Atmosphere</h1>
+        <p class="hero__subtitle">
+          Глубокий параллакс, живые глоу-частицы и реагирование на курсор превращают
+          фон в перламутровую космическую дымку.
+        </p>
+        <a class="hero__cta" href="#" role="button">Начать вдохновение</a>
+      </header>
+      <section class="hero__cards">
+        <article class="card">
+          <h2>Многослойный парящий свет</h2>
+          <p>
+            Облака мягкого свечения складываются друг на друга с глубиной, создавая
+            ощущение настоящего объемного пространства.
+          </p>
+        </article>
+        <article class="card">
+          <h2>Реакция на каждый жест</h2>
+          <p>
+            Курсор и прокрутка трансформируют композицию, и фон будто двигается вместе
+            с вами.
+          </p>
+        </article>
+        <article class="card">
+          <h2>Субтильная динамика</h2>
+          <p>
+            Частицы и волны медленно переливаются, не отвлекая, а добавляя глубину и
+            стиль интерфейсу.
+          </p>
+        </article>
+      </section>
+    </main>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,166 @@
+const parallaxRoot = document.getElementById("parallax");
+const layers = Array.from(parallaxRoot.querySelectorAll("[data-depth]"));
+const particlesContainer = document.getElementById("particles");
+const auroraCanvas = document.getElementById("aurora");
+const auroraCtx = auroraCanvas.getContext("2d");
+
+const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const pointer = { x: 0, y: 0 };
+const velocity = { x: 0, y: 0 };
+const scroll = { current: 0, target: 0 };
+const parallaxStrength = { base: 42, particles: 70 };
+const orbs = [];
+
+const auroraWaves = new Array(3).fill(0).map((_, idx) => ({
+  amplitude: 90 + idx * 40,
+  frequency: 0.7 + idx * 0.35,
+  speed: 0.18 + idx * 0.05,
+  baseY: 0.22 + idx * 0.16,
+  hue: 180 + idx * 70,
+  hueShift: 80 + idx * 20,
+  alpha: 0.35 - idx * 0.08,
+  phase: Math.random() * Math.PI * 2,
+}));
+
+function resizeAurora() {
+  const scale = 1.6;
+  auroraCanvas.width = Math.ceil(window.innerWidth * scale);
+  auroraCanvas.height = Math.ceil(window.innerHeight * scale);
+}
+
+function drawAurora(time) {
+  if (!auroraCtx) return;
+  const { width, height } = auroraCanvas;
+  auroraCtx.clearRect(0, 0, width, height);
+  auroraCtx.globalCompositeOperation = "lighter";
+
+  auroraWaves.forEach((wave, index) => {
+    const progress = time * 0.001 * wave.speed + wave.phase;
+    const baseY = height * wave.baseY;
+    const amplitude = prefersReduced ? wave.amplitude * 0.3 : wave.amplitude;
+    auroraCtx.beginPath();
+    auroraCtx.moveTo(0, height);
+    auroraCtx.lineTo(0, baseY);
+
+    const steps = 24 + index * 12;
+    for (let i = 0; i <= steps; i += 1) {
+      const t = i / steps;
+      const x = t * width;
+      const waveShift = Math.sin(t * Math.PI * 2 * wave.frequency + progress) * amplitude;
+      const y = baseY + waveShift;
+      auroraCtx.lineTo(x, y);
+    }
+
+    auroraCtx.lineTo(width, height);
+    auroraCtx.closePath();
+
+    const gradient = auroraCtx.createLinearGradient(0, baseY - amplitude, width, baseY + amplitude);
+    gradient.addColorStop(0, `hsla(${wave.hue}, 90%, 70%, ${wave.alpha})`);
+    gradient.addColorStop(0.4, `hsla(${wave.hue + wave.hueShift * 0.5}, 95%, 65%, ${wave.alpha * 1.2})`);
+    gradient.addColorStop(0.85, `hsla(${wave.hue + wave.hueShift}, 90%, 60%, ${wave.alpha * 0.75})`);
+    gradient.addColorStop(1, `hsla(${wave.hue + wave.hueShift * 1.4}, 90%, 55%, 0)`);
+
+    auroraCtx.fillStyle = gradient;
+    auroraCtx.globalAlpha = prefersReduced ? 0.45 : 0.75 - index * 0.1;
+    auroraCtx.fill();
+  });
+
+  auroraCtx.globalAlpha = 1;
+}
+
+function createParticles() {
+  const targetCount = prefersReduced ? 14 : window.innerWidth < 720 ? 20 : 34;
+  particlesContainer.innerHTML = "";
+  orbs.length = 0;
+
+  for (let i = 0; i < targetCount; i += 1) {
+    const orb = document.createElement("span");
+    const size = prefersReduced ? 50 + Math.random() * 110 : 80 + Math.random() * 180;
+    const blur = Math.random() * (prefersReduced ? 10 : 22);
+    const hue = 180 + Math.random() * 160;
+    const depth = 0.2 + Math.random() * 0.7;
+    const floatSpeed = 0.3 + Math.random() * 1.4;
+
+    orb.style.setProperty("--size", `${size}px`);
+    orb.style.setProperty("--blur", `${blur}px`);
+    orb.style.setProperty("--hue", `${hue}`);
+    orb.style.setProperty("--delay", `${Math.random() * -10}s`);
+
+    orb.style.left = `${Math.random() * 100}%`;
+    orb.style.top = `${Math.random() * 100}%`;
+
+    orb.dataset.depth = depth.toString();
+    orb.dataset.floatSpeed = floatSpeed.toString();
+    orb.dataset.offset = (Math.random() * Math.PI * 2).toString();
+
+    particlesContainer.appendChild(orb);
+    orbs.push(orb);
+  }
+}
+
+function handlePointer(event) {
+  const x = event.touches ? event.touches[0].clientX : event.clientX;
+  const y = event.touches ? event.touches[0].clientY : event.clientY;
+  const ratioX = (x / window.innerWidth) * 2 - 1;
+  const ratioY = (y / window.innerHeight) * 2 - 1;
+  pointer.x = ratioX;
+  pointer.y = ratioY;
+}
+
+function handleScroll() {
+  scroll.target = window.scrollY || window.pageYOffset || 0;
+}
+
+function updateParallax(time) {
+  velocity.x += (pointer.x - velocity.x) * 0.08;
+  velocity.y += (pointer.y - velocity.y) * 0.08;
+  scroll.current += (scroll.target - scroll.current) * 0.1;
+
+  layers.forEach((layer) => {
+    const depth = Number(layer.dataset.depth || 0);
+    const translateX = velocity.x * depth * parallaxStrength.base;
+    const translateY = velocity.y * depth * parallaxStrength.base + scroll.current * depth * 0.25;
+    const scale = 1.05 + depth * 0.08;
+
+    layer.style.transform = `translate3d(${translateX}px, ${translateY}px, 0) scale(${scale})`;
+  });
+
+  const timeFactor = time * 0.0005;
+
+  orbs.forEach((orb) => {
+    const depth = Number(orb.dataset.depth || 0.5);
+    const offset = Number(orb.dataset.offset || 0);
+    const speed = Number(orb.dataset.floatSpeed || 1);
+
+    const floatX = Math.sin(timeFactor * speed + offset) * (prefersReduced ? 6 : 18);
+    const floatY = Math.cos(timeFactor * speed * 0.8 + offset) * (prefersReduced ? 10 : 26);
+
+    const translateX = velocity.x * depth * parallaxStrength.particles + floatX;
+    const translateY = velocity.y * depth * parallaxStrength.particles + floatY + scroll.current * depth * 0.35;
+
+    orb.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+  });
+
+  drawAurora(time);
+  requestAnimationFrame(updateParallax);
+}
+
+function init() {
+  resizeAurora();
+  createParticles();
+  handleScroll();
+
+  window.addEventListener("resize", () => {
+    resizeAurora();
+    createParticles();
+  });
+
+  window.addEventListener("mousemove", handlePointer);
+  window.addEventListener("touchmove", handlePointer, { passive: true });
+  window.addEventListener("scroll", handleScroll, { passive: true });
+
+  requestAnimationFrame(updateParallax);
+}
+
+init();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,238 @@
+:root {
+  color-scheme: dark;
+  --bg-base: #050817;
+  --accent-1: #40c9ff;
+  --accent-2: #b66dff;
+  --accent-3: #ff9d6c;
+  --text-strong: #f6f7ff;
+  --text-muted: rgba(239, 241, 255, 0.78);
+  --card-bg: rgba(11, 16, 37, 0.72);
+  --card-border: rgba(130, 150, 255, 0.24);
+  --glass-blur: 18px;
+  --max-width: min(92vw, 1100px);
+  --transition-speed: 260ms;
+  font-family: "Poppins", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 95, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(255, 93, 177, 0.22), transparent 50%),
+    radial-gradient(circle at 50% 75%, rgba(47, 255, 204, 0.18), transparent 50%),
+    var(--bg-base);
+  color: var(--text-strong);
+  font-family: inherit;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cg fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='0.5'%3E%3Cpath d='M0 80 Q40 20 80 80 T160 80'/%3E%3Cpath d='M0 110 Q60 60 110 110 T220 110'/%3E%3C/g%3E%3C/svg%3E")
+    repeat;
+  opacity: 0.3;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+main.hero {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(4rem, 8vw, 8rem) 0;
+  z-index: 1;
+}
+
+.hero__content {
+  width: var(--max-width);
+  padding: clamp(1rem, 3vw, 2.5rem);
+  border-radius: 32px;
+  backdrop-filter: blur(var(--glass-blur));
+  background: linear-gradient(120deg, rgba(11, 19, 40, 0.75), rgba(11, 19, 40, 0.25));
+  border: 1px solid var(--card-border);
+  box-shadow: 0 40px 120px rgba(8, 11, 33, 0.45);
+  text-align: left;
+}
+
+.hero__eyebrow {
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0 0 1.5rem;
+}
+
+.hero__title {
+  font-size: clamp(2.7rem, 6vw, 4.2rem);
+  margin: 0 0 1rem;
+  font-weight: 600;
+}
+
+.hero__subtitle {
+  margin: 0 0 2rem;
+  color: var(--text-muted);
+  max-width: 52ch;
+  line-height: 1.8;
+}
+
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  color: var(--text-strong);
+  background: linear-gradient(135deg, rgba(64, 201, 255, 0.9), rgba(182, 109, 255, 0.9));
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+  box-shadow: 0 18px 40px rgba(64, 201, 255, 0.35);
+}
+
+.hero__cta::after {
+  content: "→";
+  font-size: 1.1em;
+  transition: transform var(--transition-speed) ease;
+}
+
+.hero__cta:hover,
+.hero__cta:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 55px rgba(182, 109, 255, 0.45);
+}
+
+.hero__cta:hover::after,
+.hero__cta:focus-visible::after {
+  transform: translateX(6px);
+}
+
+.hero__cards {
+  width: var(--max-width);
+  margin: clamp(3rem, 6vw, 5rem) auto 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.5rem, 3vw, 3rem);
+}
+
+.card {
+  padding: clamp(1.5rem, 4vw, 2.8rem);
+  border-radius: 28px;
+  background: linear-gradient(160deg, rgba(8, 12, 27, 0.78), rgba(8, 12, 27, 0.45));
+  border: 1px solid rgba(110, 135, 255, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 25px 60px rgba(4, 7, 18, 0.55);
+  backdrop-filter: blur(var(--glass-blur));
+  color: var(--text-muted);
+  line-height: 1.7;
+  transition: transform 320ms ease, border-color 320ms ease;
+}
+
+.card h2 {
+  margin-top: 0;
+  color: var(--text-strong);
+  font-size: 1.2rem;
+}
+
+.card:hover {
+  transform: translateY(-10px) scale(1.01);
+  border-color: rgba(182, 109, 255, 0.5);
+}
+
+.parallax {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  perspective: 1200px;
+  z-index: 0;
+}
+
+.layer {
+  position: absolute;
+  inset: -20%;
+  transform-style: preserve-3d;
+  will-change: transform, filter;
+}
+
+.layer--back {
+  background: radial-gradient(circle at 15% 20%, rgba(26, 119, 255, 0.45), transparent 55%),
+    radial-gradient(circle at 85% 45%, rgba(171, 64, 255, 0.35), transparent 52%),
+    radial-gradient(circle at 45% 75%, rgba(255, 145, 66, 0.28), transparent 50%),
+    radial-gradient(circle at 60% 40%, rgba(66, 255, 197, 0.2), transparent 48%);
+  filter: blur(60px);
+}
+
+.layer--mid {
+  background: conic-gradient(from 120deg at 50% 50%, rgba(82, 222, 255, 0.55), rgba(146, 66, 255, 0.4), rgba(255, 128, 100, 0.4), rgba(82, 222, 255, 0.55));
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  filter: blur(50px) saturate(140%);
+}
+
+.layer--front {
+  background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.35), transparent 35%),
+    radial-gradient(circle at 70% 60%, rgba(138, 255, 240, 0.45), transparent 45%),
+    radial-gradient(circle at 30% 70%, rgba(233, 137, 255, 0.35), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: 0.7;
+  filter: blur(40px) saturate(120%);
+}
+
+.particles {
+  position: absolute;
+  inset: 0;
+}
+
+.particles span {
+  position: absolute;
+  width: var(--size, 120px);
+  height: var(--size, 120px);
+  border-radius: 50%;
+  opacity: 0.75;
+  background: radial-gradient(circle, hsla(var(--hue, 200), 90%, 75%, 0.9) 0%, hsla(var(--hue, 200), 90%, 55%, 0.35) 55%, transparent 100%);
+  filter: blur(var(--blur, 0px));
+  mix-blend-mode: screen;
+  animation: shimmer 12s ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(0.9);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translate3d(0, 0, 0) scale(1.2);
+    opacity: 1;
+  }
+}
+
+canvas.aurora {
+  position: absolute;
+  inset: -30%;
+  width: 160%;
+  height: 160%;
+  filter: blur(60px) saturate(120%);
+  mix-blend-mode: screen;
+}
+
+@media (max-width: 720px) {
+  .hero__content {
+    text-align: center;
+  }
+  .hero__subtitle {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .hero__cards {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add dreamwave landing markup with layered parallax scene and showcase copy
- craft glassmorphism-inspired styling with glowing gradients, floating particles, and aurora canvas backdrop
- implement JavaScript-driven pointer/scroll parallax, animated orbs, and aurora wave rendering respecting reduced motion

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68cd0d54d8b8832ba2c3c6b681abc830