### PR TITLE
Add monochrome glassmorphism portfolio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,18 @@
 </head>
 <body>
   <div class="grid-bg"></div>
+  <div class="ambient ambient--one"></div>
+  <div class="ambient ambient--two"></div>
+  <nav class="glass site-nav" aria-label="Primary">
+    <span class="site-nav__brand doto-700" aria-hidden="true">AC</span>
+    <ul class="site-nav__list dotgothic16-regular">
+      <li class="site-nav__item"><a class="site-nav__link is-active" href="#about">About</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="#projects">Projects</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="#process">Process</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="#services">Capabilities</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="#contact">Contact</a></li>
+    </ul>
+  </nav>
   <header class="glass hero">
     <div class="hero__badge dotgothic16-regular">Creative coder</div>
     <h1 class="hero__title doto-900">Hello, I'm Alex</h1>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Портфолио — Черно-белая эстетика</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="grid-bg"></div>
+  <header class="glass hero">
+    <div class="hero__badge dotgothic16-regular">Digital artisan</div>
+    <h1 class="hero__title doto-900">Привет, я Егор</h1>
+    <p class="hero__subtitle dotgothic16-regular">Создаю минималистичные цифровые продукты с характером, сочетающие технологичность и эмоциональность.</p>
+    <div class="hero__cta">
+      <a class="btn btn--primary" href="#projects">Проекты</a>
+      <a class="btn btn--ghost" href="#contact">Связаться</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="glass section" id="about">
+      <h2 class="section__title doto-700">Обо мне</h2>
+      <div class="section__content">
+        <p class="lead dotgothic16-regular">Я дизайнер и фронтенд-разработчик, создающий сайты и интерфейсы с фокусом на эстетике, плавности и внимании к деталям. Мой подход — это сочетание структурированной типографики, стеклянных поверхностей и чётких акцентов.</p>
+        <ul class="stats">
+          <li class="stats__item">
+            <span class="stats__value doto-500">8+</span>
+            <span class="stats__label dotgothic16-regular">лет опыта</span>
+          </li>
+          <li class="stats__item">
+            <span class="stats__value doto-500">45</span>
+            <span class="stats__label dotgothic16-regular">завершённых проектов</span>
+          </li>
+          <li class="stats__item">
+            <span class="stats__value doto-500">12</span>
+            <span class="stats__label dotgothic16-regular">наград &amp; публикаций</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section" id="projects">
+      <h2 class="section__title doto-700">Проекты</h2>
+      <div class="projects">
+        <article class="project glass">
+          <div class="project__tag dotgothic16-regular">UX / UI</div>
+          <h3 class="project__title doto-500">Сервис для медитаций</h3>
+          <p class="project__description dotgothic16-regular">Чёрно-белый интерфейс, который позволяет пользователю сосредоточиться на дыхании и ощущениях. Плавные микроанимации создают атмосферу спокойствия.</p>
+          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+        </article>
+        <article class="project glass">
+          <div class="project__tag dotgothic16-regular">Motion / WebGL</div>
+          <h3 class="project__title doto-500">Иммерсивный лендинг</h3>
+          <p class="project__description dotgothic16-regular">Лендинг с элементами WebGL и стеклянными карточками, создающими эффект глубины. Анимации реагируют на движение курсора.</p>
+          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+        </article>
+        <article class="project glass">
+          <div class="project__tag dotgothic16-regular">Art Direction</div>
+          <h3 class="project__title doto-500">Виртуальная галерея</h3>
+          <p class="project__description dotgothic16-regular">Серия интерактивных выставок, где световые контуры и отражения подчёркивают каждую работу. Монохромная палитра и живые тени.</p>
+          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="glass section" id="process">
+      <h2 class="section__title doto-700">Процесс</h2>
+      <ol class="timeline">
+        <li class="timeline__item">
+          <span class="timeline__step doto-400">01</span>
+          <div>
+            <h3 class="timeline__title doto-500">Исследование</h3>
+            <p class="timeline__description dotgothic16-regular">Погружаюсь в контекст, аудиторию и задачи, чтобы сформировать визуальную стратегию и систему смыслов.</p>
+          </div>
+        </li>
+        <li class="timeline__item">
+          <span class="timeline__step doto-400">02</span>
+          <div>
+            <h3 class="timeline__title doto-500">Концепция</h3>
+            <p class="timeline__description dotgothic16-regular">Создаю концепт через moodboard, типографику и ключевые экраны. Ищу баланс между технологичностью и эмоцией.</p>
+          </div>
+        </li>
+        <li class="timeline__item">
+          <span class="timeline__step doto-400">03</span>
+          <div>
+            <h3 class="timeline__title doto-500">Реализация</h3>
+            <p class="timeline__description dotgothic16-regular">Перевожу концепцию в рабочий продукт: верстаю, интегрирую анимации, тестирую и улучшаю.</p>
+          </div>
+        </li>
+      </ol>
+    </section>
+
+    <section class="section section--split" id="services">
+      <div class="glass split-card">
+        <h2 class="section__title doto-700">Услуги</h2>
+        <ul class="service-list">
+          <li class="service-list__item dotgothic16-regular">Дизайн сайтов и интерфейсов</li>
+          <li class="service-list__item dotgothic16-regular">Микроанимации и Motion</li>
+          <li class="service-list__item dotgothic16-regular">Арт-дирекшн и брендинг</li>
+          <li class="service-list__item dotgothic16-regular">Прототипирование и разработка</li>
+        </ul>
+      </div>
+      <div class="glass split-card">
+        <h2 class="section__title doto-700">Инструменты</h2>
+        <div class="tags">
+          <span class="tag doto-400">Figma</span>
+          <span class="tag doto-400">Framer</span>
+          <span class="tag doto-400">After Effects</span>
+          <span class="tag doto-400">Three.js</span>
+          <span class="tag doto-400">Svelte</span>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="glass footer" id="contact">
+    <h2 class="section__title doto-700">Давайте создавать</h2>
+    <p class="footer__text dotgothic16-regular">Открыт к сотрудничеству и новым идеям. Пишите на почту или в мессенджеры.</p>
+    <div class="footer__links">
+      <a class="footer__link doto-400" href="mailto:hello@egor.design">hello@egor.design</a>
+      <a class="footer__link doto-400" href="https://t.me/egor_design">Telegram</a>
+      <a class="footer__link doto-400" href="https://www.behance.net/egor">Behance</a>
+    </div>
+    <p class="footer__copyright dotgothic16-regular">© 2024 Егор Ковалёв. Все права защищены.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,6 @@
 </head>
 <body>
   <div class="grid-bg"></div>
-  <div class="ambient ambient--one"></div>
-  <div class="ambient ambient--two"></div>
   <nav class="glass site-nav" aria-label="Primary">
     <span class="site-nav__brand doto-700" aria-hidden="true">AC</span>
     <ul class="site-nav__list dotgothic16-regular">
@@ -23,6 +21,7 @@
       <li class="site-nav__item"><a class="site-nav__link" href="#projects">Projects</a></li>
       <li class="site-nav__item"><a class="site-nav__link" href="#process">Process</a></li>
       <li class="site-nav__item"><a class="site-nav__link" href="#services">Capabilities</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="lab.html">Lab</a></li>
       <li class="site-nav__item"><a class="site-nav__link" href="#contact">Contact</a></li>
     </ul>
   </nav>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Портфолио — Черно-белая эстетика</title>
+  <title>Monochrome Developer Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap" rel="stylesheet">
@@ -15,83 +15,83 @@
 <body>
   <div class="grid-bg"></div>
   <header class="glass hero">
-    <div class="hero__badge dotgothic16-regular">Digital artisan</div>
-    <h1 class="hero__title doto-900">Привет, я Егор</h1>
-    <p class="hero__subtitle dotgothic16-regular">Создаю минималистичные цифровые продукты с характером, сочетающие технологичность и эмоциональность.</p>
+    <div class="hero__badge dotgothic16-regular">Creative coder</div>
+    <h1 class="hero__title doto-900">Hello, I'm Alex</h1>
+    <p class="hero__subtitle dotgothic16-regular">I engineer monochrome experiences where precise code, thoughtful motion, and calm aesthetics meet.</p>
     <div class="hero__cta">
-      <a class="btn btn--primary" href="#projects">Проекты</a>
-      <a class="btn btn--ghost" href="#contact">Связаться</a>
+      <a class="btn btn--primary" href="#projects">Projects</a>
+      <a class="btn btn--ghost" href="#contact">Contact</a>
     </div>
   </header>
 
   <main>
     <section class="glass section" id="about">
-      <h2 class="section__title doto-700">Обо мне</h2>
+      <h2 class="section__title doto-700">About</h2>
       <div class="section__content">
-        <p class="lead dotgothic16-regular">Я дизайнер и фронтенд-разработчик, создающий сайты и интерфейсы с фокусом на эстетике, плавности и внимании к деталям. Мой подход — это сочетание структурированной типографики, стеклянных поверхностей и чётких акцентов.</p>
+        <p class="lead dotgothic16-regular">I'm a software engineer and creative developer crafting interfaces with a balance of performance, emotion, and meticulous detail. My process blends structured typography, glassmorphism, and responsive interactions.</p>
         <ul class="stats">
           <li class="stats__item">
             <span class="stats__value doto-500">8+</span>
-            <span class="stats__label dotgothic16-regular">лет опыта</span>
+            <span class="stats__label dotgothic16-regular">years shipping products</span>
           </li>
           <li class="stats__item">
             <span class="stats__value doto-500">45</span>
-            <span class="stats__label dotgothic16-regular">завершённых проектов</span>
+            <span class="stats__label dotgothic16-regular">launched builds</span>
           </li>
           <li class="stats__item">
             <span class="stats__value doto-500">12</span>
-            <span class="stats__label dotgothic16-regular">наград &amp; публикаций</span>
+            <span class="stats__label dotgothic16-regular">talks &amp; features</span>
           </li>
         </ul>
       </div>
     </section>
 
     <section class="section" id="projects">
-      <h2 class="section__title doto-700">Проекты</h2>
+      <h2 class="section__title doto-700">Projects</h2>
       <div class="projects">
         <article class="project glass">
-          <div class="project__tag dotgothic16-regular">UX / UI</div>
-          <h3 class="project__title doto-500">Сервис для медитаций</h3>
-          <p class="project__description dotgothic16-regular">Чёрно-белый интерфейс, который позволяет пользователю сосредоточиться на дыхании и ощущениях. Плавные микроанимации создают атмосферу спокойствия.</p>
-          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+          <div class="project__tag dotgothic16-regular">Frontend / Systems</div>
+          <h3 class="project__title doto-500">Signal Ops Dashboard</h3>
+          <p class="project__description dotgothic16-regular">A realtime operations cockpit for monitoring distributed services. Glass cards surface metrics while smooth transitions guide focus.</p>
+          <a class="project__link dotgothic16-regular" href="#">View case study</a>
         </article>
         <article class="project glass">
-          <div class="project__tag dotgothic16-regular">Motion / WebGL</div>
-          <h3 class="project__title doto-500">Иммерсивный лендинг</h3>
-          <p class="project__description dotgothic16-regular">Лендинг с элементами WebGL и стеклянными карточками, создающими эффект глубины. Анимации реагируют на движение курсора.</p>
-          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+          <div class="project__tag dotgothic16-regular">WebGL / Creative Tech</div>
+          <h3 class="project__title doto-500">Generative Playground</h3>
+          <p class="project__description dotgothic16-regular">An interactive canvas powered by shaders and particle systems, letting users sculpt sound-reactive forms in monochrome.</p>
+          <a class="project__link dotgothic16-regular" href="#">View case study</a>
         </article>
         <article class="project glass">
-          <div class="project__tag dotgothic16-regular">Art Direction</div>
-          <h3 class="project__title doto-500">Виртуальная галерея</h3>
-          <p class="project__description dotgothic16-regular">Серия интерактивных выставок, где световые контуры и отражения подчёркивают каждую работу. Монохромная палитра и живые тени.</p>
-          <a class="project__link dotgothic16-regular" href="#">Смотреть кейс</a>
+          <div class="project__tag dotgothic16-regular">Documentation</div>
+          <h3 class="project__title doto-500">API Knowledge Base</h3>
+          <p class="project__description dotgothic16-regular">Developer docs with adaptive navigation, live code sandboxes, and ambient motion to keep focus without distraction.</p>
+          <a class="project__link dotgothic16-regular" href="#">View case study</a>
         </article>
       </div>
     </section>
 
     <section class="glass section" id="process">
-      <h2 class="section__title doto-700">Процесс</h2>
+      <h2 class="section__title doto-700">Process</h2>
       <ol class="timeline">
         <li class="timeline__item">
           <span class="timeline__step doto-400">01</span>
           <div>
-            <h3 class="timeline__title doto-500">Исследование</h3>
-            <p class="timeline__description dotgothic16-regular">Погружаюсь в контекст, аудиторию и задачи, чтобы сформировать визуальную стратегию и систему смыслов.</p>
+            <h3 class="timeline__title doto-500">Discovery &amp; Scoping</h3>
+            <p class="timeline__description dotgothic16-regular">Dive into product goals, audience, and constraints to outline the technical narrative and experience arc.</p>
           </div>
         </li>
         <li class="timeline__item">
           <span class="timeline__step doto-400">02</span>
           <div>
-            <h3 class="timeline__title doto-500">Концепция</h3>
-            <p class="timeline__description dotgothic16-regular">Создаю концепт через moodboard, типографику и ключевые экраны. Ищу баланс между технологичностью и эмоцией.</p>
+            <h3 class="timeline__title doto-500">Architecture &amp; Design</h3>
+            <p class="timeline__description dotgothic16-regular">Sketch flows, define components, and prototype interactions that bridge clarity, performance, and delight.</p>
           </div>
         </li>
         <li class="timeline__item">
           <span class="timeline__step doto-400">03</span>
           <div>
-            <h3 class="timeline__title doto-500">Реализация</h3>
-            <p class="timeline__description dotgothic16-regular">Перевожу концепцию в рабочий продукт: верстаю, интегрирую анимации, тестирую и улучшаю.</p>
+            <h3 class="timeline__title doto-500">Build &amp; Iterate</h3>
+            <p class="timeline__description dotgothic16-regular">Ship accessible, animated experiences, integrate seamlessly, and refine through feedback loops.</p>
           </div>
         </li>
       </ol>
@@ -99,36 +99,36 @@
 
     <section class="section section--split" id="services">
       <div class="glass split-card">
-        <h2 class="section__title doto-700">Услуги</h2>
+        <h2 class="section__title doto-700">Capabilities</h2>
         <ul class="service-list">
-          <li class="service-list__item dotgothic16-regular">Дизайн сайтов и интерфейсов</li>
-          <li class="service-list__item dotgothic16-regular">Микроанимации и Motion</li>
-          <li class="service-list__item dotgothic16-regular">Арт-дирекшн и брендинг</li>
-          <li class="service-list__item dotgothic16-regular">Прототипирование и разработка</li>
+          <li class="service-list__item dotgothic16-regular">Full-stack product engineering</li>
+          <li class="service-list__item dotgothic16-regular">Creative coding &amp; WebGL prototypes</li>
+          <li class="service-list__item dotgothic16-regular">Design systems &amp; UI engineering</li>
+          <li class="service-list__item dotgothic16-regular">Automation &amp; developer tooling</li>
         </ul>
       </div>
       <div class="glass split-card">
-        <h2 class="section__title doto-700">Инструменты</h2>
+        <h2 class="section__title doto-700">Stack</h2>
         <div class="tags">
-          <span class="tag doto-400">Figma</span>
-          <span class="tag doto-400">Framer</span>
-          <span class="tag doto-400">After Effects</span>
+          <span class="tag doto-400">TypeScript</span>
+          <span class="tag doto-400">React</span>
+          <span class="tag doto-400">Next.js</span>
           <span class="tag doto-400">Three.js</span>
-          <span class="tag doto-400">Svelte</span>
+          <span class="tag doto-400">Node.js</span>
         </div>
       </div>
     </section>
   </main>
 
   <footer class="glass footer" id="contact">
-    <h2 class="section__title doto-700">Давайте создавать</h2>
-    <p class="footer__text dotgothic16-regular">Открыт к сотрудничеству и новым идеям. Пишите на почту или в мессенджеры.</p>
+    <h2 class="section__title doto-700">Let's build</h2>
+    <p class="footer__text dotgothic16-regular">Open to collaborations and experimental ideas. Reach out for product engineering, creative coding, or technical direction.</p>
     <div class="footer__links">
-      <a class="footer__link doto-400" href="mailto:hello@egor.design">hello@egor.design</a>
-      <a class="footer__link doto-400" href="https://t.me/egor_design">Telegram</a>
-      <a class="footer__link doto-400" href="https://www.behance.net/egor">Behance</a>
+      <a class="footer__link doto-400" href="mailto:hello@alex.dev">hello@alex.dev</a>
+      <a class="footer__link doto-400" href="https://t.me/alex_codes">Telegram</a>
+      <a class="footer__link doto-400" href="https://github.com/alex">GitHub</a>
     </div>
-    <p class="footer__copyright dotgothic16-regular">© 2024 Егор Ковалёв. Все права защищены.</p>
+    <p class="footer__copyright dotgothic16-regular">© 2024 Alex Carter. All rights reserved.</p>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -120,13 +120,36 @@
         </ul>
       </div>
       <div class="glass split-card">
-        <h2 class="section__title doto-700">Stack</h2>
-        <div class="tags">
-          <span class="tag doto-400">TypeScript</span>
-          <span class="tag doto-400">React</span>
-          <span class="tag doto-400">Next.js</span>
-          <span class="tag doto-400">Three.js</span>
-          <span class="tag doto-400">Node.js</span>
+        <h2 class="section__title doto-700">Core Toolkit</h2>
+        <div class="stack-grid">
+          <article class="stack-pill">
+            <span class="stack-pill__label dotgothic16-regular">Interface</span>
+            <h3 class="stack-pill__title doto-500">TypeScript &amp; React</h3>
+            <p class="stack-pill__description dotgothic16-regular">
+              Component-driven systems, design tokens, and accessible motion choreography.
+            </p>
+          </article>
+          <article class="stack-pill">
+            <span class="stack-pill__label dotgothic16-regular">Platforms</span>
+            <h3 class="stack-pill__title doto-500">Next.js &amp; Node.js</h3>
+            <p class="stack-pill__description dotgothic16-regular">
+              Hybrid rendering, serverless workflows, and resilient API integrations.
+            </p>
+          </article>
+          <article class="stack-pill">
+            <span class="stack-pill__label dotgothic16-regular">Creative Tech</span>
+            <h3 class="stack-pill__title doto-500">Three.js &amp; GLSL</h3>
+            <p class="stack-pill__description dotgothic16-regular">
+              Shader-driven visuals, generative motion, and immersive spatial interactions.
+            </p>
+          </article>
+          <article class="stack-pill">
+            <span class="stack-pill__label dotgothic16-regular">Tooling</span>
+            <h3 class="stack-pill__title doto-500">GraphQL &amp; CI/CD</h3>
+            <p class="stack-pill__description dotgothic16-regular">
+              Robust schema design, automated quality gates, and observability pipelines.
+            </p>
+          </article>
         </div>
       </div>
     </section>

--- a/lab.html
+++ b/lab.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monochrome Lab — Alex Carter</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="lab">
+  <div class="grid-bg"></div>
+  <nav class="glass site-nav" aria-label="Secondary">
+    <span class="site-nav__brand doto-700" aria-hidden="true">AC</span>
+    <ul class="site-nav__list dotgothic16-regular">
+      <li class="site-nav__item"><a class="site-nav__link" href="index.html">Portfolio</a></li>
+      <li class="site-nav__item"><a class="site-nav__link" href="index.html#contact">Contact</a></li>
+      <li class="site-nav__item"><a class="site-nav__link is-active" href="lab.html">Lab</a></li>
+    </ul>
+  </nav>
+
+  <header class="glass lab-hero">
+    <span class="lab-hero__kicker dotgothic16-regular">Monochrome Lab</span>
+    <h1 class="lab-hero__title doto-900">Experiments &amp; Motion Studies</h1>
+    <p class="lab-hero__description dotgothic16-regular">
+      Exploring tactile lighting, shader sketches, and interface prototypes that extend the portfolio language into interactive research artifacts.
+    </p>
+    <div class="lab-hero__meta dotgothic16-regular">
+      <span>Shader artistry</span>
+      <span>Rapid prototyping</span>
+      <span>Motion direction</span>
+    </div>
+  </header>
+
+  <main class="lab-main">
+    <section class="glass lab-section">
+      <h2 class="lab-section__title doto-700">Current explorations</h2>
+      <div class="lab-grid">
+        <article class="glass lab-card">
+          <span class="lab-card__kicker dotgothic16-regular">GLSL study</span>
+          <h3 class="lab-card__title doto-500">Procedural Glass Matter</h3>
+          <p class="lab-card__description dotgothic16-regular">
+            Layered refraction and caustic-inspired distortions rendered through signed distance fields, tuned for realtime responsiveness.
+          </p>
+          <div class="lab-card__footer dotgothic16-regular">
+            <span>Codepen</span>
+            <span>Live shader</span>
+          </div>
+        </article>
+        <article class="glass lab-card">
+          <span class="lab-card__kicker dotgothic16-regular">Interface motion</span>
+          <h3 class="lab-card__title doto-500">Holographic Control Deck</h3>
+          <p class="lab-card__description dotgothic16-regular">
+            Elastic navigation prototypes with volumetric parallax, mapping depth cues to pointer velocity for expressive yet precise feedback.
+          </p>
+          <div class="lab-card__footer dotgothic16-regular">
+            <span>Framer</span>
+            <span>Prototype</span>
+          </div>
+        </article>
+        <article class="glass lab-card">
+          <span class="lab-card__kicker dotgothic16-regular">Sound reactive</span>
+          <h3 class="lab-card__title doto-500">Monochrome Pulse Fields</h3>
+          <p class="lab-card__description dotgothic16-regular">
+            Audio-synced grids that translate amplitude into shimmering vector fields, designed for ambient installations and live AV.
+          </p>
+          <div class="lab-card__footer dotgothic16-regular">
+            <span>Three.js</span>
+            <span>Beta</span>
+          </div>
+        </article>
+        <article class="glass lab-card">
+          <span class="lab-card__kicker dotgothic16-regular">Tooling</span>
+          <h3 class="lab-card__title doto-500">Pipeline Automations</h3>
+          <p class="lab-card__description dotgothic16-regular">
+            CI/CD recipes for creative coding stacks with linting, preview deploys, and performance budgets embedded from the first commit.
+          </p>
+          <div class="lab-card__footer dotgothic16-regular">
+            <span>Node</span>
+            <span>Workflow</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="glass lab-section">
+      <h2 class="lab-section__title doto-700">Process notes</h2>
+      <div class="lab-chronology">
+        <div class="lab-chronology__row">
+          <span class="lab-chronology__time dotgothic16-regular">Week 14</span>
+          <h3 class="lab-chronology__title doto-500">Adaptive grid engine</h3>
+          <p class="lab-chronology__description dotgothic16-regular">
+            Refined the tile system into a modular utility that scales from hero canvases to dense dashboards without losing clarity.
+          </p>
+        </div>
+        <div class="lab-chronology__row">
+          <span class="lab-chronology__time dotgothic16-regular">Week 12</span>
+          <h3 class="lab-chronology__title doto-500">Latency-aware motion</h3>
+          <p class="lab-chronology__description dotgothic16-regular">
+            Prototyped easing curves and haptic cues that adapt to network conditions, keeping transitions crisp on remote collaborations.
+          </p>
+        </div>
+        <div class="lab-chronology__row">
+          <span class="lab-chronology__time dotgothic16-regular">Week 10</span>
+          <h3 class="lab-chronology__title doto-500">Glass typography</h3>
+          <p class="lab-chronology__description dotgothic16-regular">
+            Experimented with variable Doto weights to craft responsive headline systems with balanced contrast and accessibility.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="glass lab-section">
+      <h2 class="lab-section__title doto-700">Get in touch</h2>
+      <p class="lab-hero__description dotgothic16-regular">
+        The lab is an evolving space—reach out if you're interested in collaborating on experimental interfaces, immersive installations, or technical art direction.
+      </p>
+      <div class="lab-hero__meta dotgothic16-regular">
+        <a class="site-nav__link" href="mailto:hello@alex.dev">Email</a>
+        <a class="site-nav__link" href="https://github.com/alex">GitHub</a>
+        <a class="site-nav__link" href="https://t.me/alex_codes">Telegram</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="glass lab-footer dotgothic16-regular">
+    <p>© 2024 Alex Carter. Monochrome Lab.</p>
+    <p><a class="site-nav__link" href="index.html">Return to portfolio</a></p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -46,185 +46,10 @@ body {
     linear-gradient(0deg, rgba(255, 255, 255, 0.05) 1px, transparent 0);
   background-size: 80px 80px;
   background-position: center;
-  opacity: 0.65;
+  opacity: 0.5;
   z-index: 0;
-  animation: gridPulse 12s ease-in-out infinite;
 }
 
-.grid-bg::before,
-.grid-bg::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-repeat: no-repeat;
-  background-size: 80px 80px;
-  mix-blend-mode: screen;
-  opacity: 0;
-  animation-timing-function: ease-in-out;
-  pointer-events: none;
-}
-
-.grid-bg::before {
-  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0) 68%);
-  filter: blur(2px);
-  animation: cellFlashOne 20s infinite;
-}
-
-.grid-bg::after {
-  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 70%);
-  filter: blur(4px);
-  animation: cellFlashTwo 26s infinite;
-  animation-delay: -8s;
-}
-
-.ambient {
-  pointer-events: none;
-  position: fixed;
-  z-index: 0;
-  border-radius: 999px;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
-  mix-blend-mode: screen;
-  filter: blur(80px);
-  opacity: 0.65;
-  transform: translate3d(0, 0, 0);
-}
-
-.ambient--one {
-  width: 460px;
-  height: 460px;
-  top: 10vh;
-  left: 12vw;
-  animation: ambientDriftOne 32s ease-in-out infinite;
-}
-
-.ambient--two {
-  width: 520px;
-  height: 520px;
-  bottom: 6vh;
-  right: 8vw;
-  animation: ambientDriftTwo 28s ease-in-out infinite;
-}
-
-@keyframes gridPulse {
-  0%,
-  100% {
-    opacity: 0.55;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.8;
-    transform: scale(1.02);
-  }
-}
-
-@keyframes cellFlashOne {
-  0%,
-  5% {
-    opacity: 0;
-  }
-  6% {
-    opacity: 0.85;
-    background-position: calc(80px * 3) calc(80px * 5);
-  }
-  9% {
-    opacity: 0;
-  }
-  22% {
-    opacity: 0;
-    background-position: calc(80px * 6) calc(80px * 2);
-  }
-  24% {
-    opacity: 0.8;
-  }
-  28% {
-    opacity: 0;
-  }
-  43% {
-    opacity: 0;
-    background-position: calc(80px * 1) calc(80px * 7);
-  }
-  45% {
-    opacity: 0.9;
-  }
-  50% {
-    opacity: 0;
-  }
-  68% {
-    opacity: 0;
-    background-position: calc(80px * 5) calc(80px * 1);
-  }
-  70% {
-    opacity: 0.75;
-  }
-  74% {
-    opacity: 0;
-  }
-  88% {
-    opacity: 0;
-    background-position: calc(80px * 2) calc(80px * 4);
-  }
-  90% {
-    opacity: 0.8;
-  }
-  94%,
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes cellFlashTwo {
-  0%,
-  8% {
-    opacity: 0;
-  }
-  10% {
-    opacity: 0.65;
-    background-position: calc(80px * 7) calc(80px * 6);
-  }
-  14% {
-    opacity: 0;
-  }
-  32% {
-    opacity: 0;
-    background-position: calc(80px * 4) calc(80px * 3);
-  }
-  34% {
-    opacity: 0.7;
-  }
-  38% {
-    opacity: 0;
-  }
-  55% {
-    opacity: 0;
-    background-position: calc(80px * 2) calc(80px * 8);
-  }
-  57% {
-    opacity: 0.75;
-  }
-  62% {
-    opacity: 0;
-  }
-  78% {
-    opacity: 0;
-    background-position: calc(80px * 8) calc(80px * 1);
-  }
-  80% {
-    opacity: 0.7;
-  }
-  84% {
-    opacity: 0;
-  }
-  94% {
-    opacity: 0;
-    background-position: calc(80px * 3) calc(80px * 6);
-  }
-  96% {
-    opacity: 0.65;
-  }
-  100% {
-    opacity: 0;
-  }
-}
 
 .glass {
   position: relative;
@@ -713,6 +538,169 @@ body {
   text-transform: uppercase;
 }
 
+body.lab {
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.lab-main {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.lab-hero {
+  padding: clamp(2.8rem, 6vw, 5rem);
+  display: grid;
+  gap: clamp(1.2rem, 3vw, 2.2rem);
+  max-width: min(960px, 100%);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.lab-hero__kicker {
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--text-medium);
+}
+
+.lab-hero__title {
+  font-size: clamp(3rem, 7vw, 4.4rem);
+  letter-spacing: -0.05em;
+}
+
+.lab-hero__description {
+  color: var(--text-medium);
+  font-size: clamp(1rem, 2.6vw, 1.35rem);
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
+.lab-hero__meta {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lab-section {
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  padding: clamp(2.4rem, 6vw, 4rem);
+  position: relative;
+  z-index: 1;
+  max-width: min(1080px, 100%);
+  margin: 0 auto;
+}
+
+.lab-section__title {
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lab-grid {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.2rem);
+}
+
+.lab-card {
+  position: relative;
+  padding: clamp(1.8rem, 4vw, 2.6rem);
+  display: grid;
+  gap: 1rem;
+  overflow: hidden;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.lab-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02));
+  opacity: 0.6;
+  transition: opacity var(--transition);
+  pointer-events: none;
+}
+
+.lab-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.lab-card__kicker {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--text-medium);
+}
+
+.lab-card__title {
+  font-size: clamp(1.4rem, 3.4vw, 2.1rem);
+}
+
+.lab-card__description {
+  color: var(--text-medium);
+}
+
+.lab-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.lab-card:hover,
+.lab-card:focus-within {
+  transform: translateY(-6px);
+  border-color: var(--border-strong);
+}
+
+.lab-card:hover::before,
+.lab-card:focus-within::before {
+  opacity: 0.85;
+}
+
+.lab-chronology {
+  display: grid;
+  gap: 1.8rem;
+}
+
+.lab-chronology__row {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.lab-chronology__time {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.lab-chronology__title {
+  font-size: clamp(1.2rem, 3vw, 1.7rem);
+}
+
+.lab-chronology__description {
+  color: var(--text-medium);
+  max-width: 60ch;
+}
+
+.lab-footer {
+  text-align: center;
+  padding: clamp(1.8rem, 4vw, 3rem);
+  display: grid;
+  gap: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 @keyframes fadeSlide {
   from {
     opacity: 0;
@@ -721,26 +709,6 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-@keyframes ambientDriftOne {
-  0%,
-  100% {
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-  50% {
-    transform: translate3d(60px, -40px, 0) scale(1.08);
-  }
-}
-
-@keyframes ambientDriftTwo {
-  0%,
-  100% {
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-  50% {
-    transform: translate3d(-80px, 50px, 0) scale(0.94);
   }
 }
 
@@ -789,6 +757,18 @@ main {
 
   .project:nth-child(3) {
     margin-top: 3rem;
+  }
+
+  .lab-main {
+    gap: clamp(2.5rem, 4vw, 3.8rem);
+  }
+
+  .lab-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lab-chronology {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,457 @@
+:root {
+  --bg-dark: #0f0f10;
+  --bg-dark-soft: rgba(24, 24, 26, 0.65);
+  --bg-light: rgba(255, 255, 255, 0.08);
+  --border-glass: rgba(255, 255, 255, 0.25);
+  --border-strong: rgba(255, 255, 255, 0.4);
+  --text-high: #f7f7f7;
+  --text-medium: #cccccc;
+  --accent: #ffffff;
+  --shadow: rgba(0, 0, 0, 0.6);
+  --transition: 280ms ease;
+  --radius: 24px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  background: var(--bg-dark);
+  color: var(--text-high);
+  font-family: "Doto", sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
+  padding: clamp(2rem, 5vw, 4rem);
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 4rem);
+}
+
+.grid-bg {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 0),
+    linear-gradient(0deg, rgba(255, 255, 255, 0.05) 1px, transparent 0);
+  background-size: 80px 80px;
+  opacity: 0.65;
+  z-index: 0;
+  animation: gridPulse 12s ease-in-out infinite;
+}
+
+@keyframes gridPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.02);
+  }
+}
+
+.glass {
+  position: relative;
+  z-index: 1;
+  border-radius: var(--radius);
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--border-glass);
+  box-shadow: 0 25px 60px -30px var(--shadow);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.glass::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(var(--radius) - 1px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  pointer-events: none;
+}
+
+.hero {
+  padding: clamp(2.5rem, 6vw, 5rem);
+  display: grid;
+  gap: clamp(1.25rem, 4vw, 2.5rem);
+  align-content: start;
+  animation: fadeSlide 900ms ease-out forwards;
+}
+
+.hero__badge {
+  width: fit-content;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+}
+
+.hero__title {
+  font-size: clamp(3rem, 8vw, 5rem);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 1.05;
+  text-shadow: 0 6px 25px rgba(0, 0, 0, 0.4);
+}
+
+.hero__subtitle {
+  max-width: 52ch;
+  color: var(--text-medium);
+  font-size: clamp(1.1rem, 3vw, 1.45rem);
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.9rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform var(--transition), background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #060606;
+  font-weight: 600;
+  box-shadow: 0 18px 38px -22px rgba(255, 255, 255, 0.9);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--border-strong);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-4px) scale(1.02);
+}
+
+.section {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(2.25rem, 5vw, 4rem);
+  position: relative;
+  z-index: 1;
+}
+
+.section__title {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.section__content {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.2rem);
+}
+
+.lead {
+  font-size: clamp(1rem, 2.8vw, 1.25rem);
+  color: var(--text-medium);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.5rem;
+  list-style: none;
+}
+
+.stats__item {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.stats__value {
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  letter-spacing: -0.03em;
+}
+
+.stats__label {
+  color: var(--text-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+}
+
+.projects {
+  display: grid;
+  gap: 1.6rem;
+}
+
+.project {
+  padding: clamp(1.8rem, 4vw, 2.8rem);
+  display: grid;
+  gap: 1rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.project__tag {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--text-medium);
+}
+
+.project__title {
+  font-size: clamp(1.5rem, 3.5vw, 2.1rem);
+}
+
+.project__description {
+  color: var(--text-medium);
+}
+
+.project__link {
+  width: fit-content;
+  position: relative;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: var(--accent);
+  text-decoration: none;
+  padding-bottom: 0.2rem;
+}
+
+.project__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--accent);
+  transform-origin: right;
+  transform: scaleX(0);
+  transition: transform var(--transition);
+}
+
+.project:hover,
+.project:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.38);
+}
+
+.project:hover .project__link::after,
+.project:focus-within .project__link::after {
+  transform-origin: left;
+  transform: scaleX(1);
+}
+
+.timeline {
+  list-style: none;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline__item {
+  display: grid;
+  grid-template-columns: minmax(50px, 1fr) 6fr;
+  gap: 1.5rem;
+  align-items: start;
+  padding: 1.2rem 1.5rem;
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition: transform var(--transition), background var(--transition);
+}
+
+.timeline__item:hover {
+  transform: translateX(6px);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.timeline__step {
+  font-size: 1.2rem;
+  letter-spacing: 0.2em;
+  color: var(--text-medium);
+}
+
+.timeline__title {
+  font-size: 1.3rem;
+}
+
+.timeline__description {
+  color: var(--text-medium);
+}
+
+.section--split {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.split-card {
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.service-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.service-list__item {
+  letter-spacing: 0.05em;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.tag {
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+}
+
+.footer {
+  padding: clamp(2.5rem, 6vw, 4rem);
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.footer__text {
+  color: var(--text-medium);
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
+.footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.footer__link {
+  text-decoration: none;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  position: relative;
+  padding-bottom: 0.2rem;
+}
+
+.footer__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.5);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--transition);
+}
+
+.footer__link:hover::after {
+  transform-origin: left;
+  transform: scaleX(1);
+}
+
+.footer__copyright {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+main {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+}
+
+.doto-900 { font-family: "Doto", sans-serif; font-weight: 900; }
+.doto-700 { font-family: "Doto", sans-serif; font-weight: 700; }
+.doto-500 { font-family: "Doto", sans-serif; font-weight: 500; }
+.doto-400 { font-family: "Doto", sans-serif; font-weight: 400; }
+.doto-300 { font-family: "Doto", sans-serif; font-weight: 300; }
+.dotgothic16-regular { font-family: "DotGothic16", sans-serif; font-weight: 400; }
+
+@media (min-width: 900px) {
+  body {
+    padding: clamp(3rem, 6vw, 6rem);
+  }
+
+  .hero {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  .hero__subtitle {
+    grid-column: span 2;
+  }
+
+  .hero__cta {
+    grid-column: span 2;
+  }
+
+  .projects {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .project:nth-child(2) {
+    margin-top: 1.5rem;
+  }
+
+  .project:nth-child(3) {
+    margin-top: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,7 @@ body {
   font-family: "Doto", sans-serif;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  scroll-behavior: smooth;
 }
 
 body {
@@ -47,6 +48,34 @@ body {
   opacity: 0.65;
   z-index: 0;
   animation: gridPulse 12s ease-in-out infinite;
+}
+
+.ambient {
+  pointer-events: none;
+  position: fixed;
+  z-index: 0;
+  border-radius: 999px;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  filter: blur(80px);
+  opacity: 0.65;
+  transform: translate3d(0, 0, 0);
+}
+
+.ambient--one {
+  width: 460px;
+  height: 460px;
+  top: 10vh;
+  left: 12vw;
+  animation: ambientDriftOne 32s ease-in-out infinite;
+}
+
+.ambient--two {
+  width: 520px;
+  height: 520px;
+  bottom: 6vh;
+  right: 8vw;
+  animation: ambientDriftTwo 28s ease-in-out infinite;
 }
 
 @keyframes gridPulse {
@@ -80,6 +109,96 @@ body {
   border-radius: calc(var(--radius) - 1px);
   border: 1px solid rgba(255, 255, 255, 0.12);
   pointer-events: none;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  flex-wrap: wrap;
+  padding: clamp(0.9rem, 2vw, 1.2rem) clamp(1.5rem, 4vw, 2.6rem);
+  position: sticky;
+  top: clamp(1rem, 4vw, 2rem);
+  z-index: 4;
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+
+.site-nav__brand {
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  letter-spacing: 0.6em;
+  text-transform: uppercase;
+  padding-left: 0.6em;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.site-nav__brand::before {
+  content: "";
+  position: absolute;
+  top: -0.35rem;
+  right: -0.6rem;
+  bottom: -0.35rem;
+  left: -0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  opacity: 0.7;
+}
+
+.site-nav__list {
+  list-style: none;
+  display: flex;
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+}
+
+.site-nav__link {
+  position: relative;
+  text-decoration: none;
+  color: var(--text-high);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  padding-bottom: 0.35rem;
+  transition: color var(--transition);
+  display: inline-flex;
+  align-items: center;
+}
+
+.site-nav__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--transition);
+}
+
+.site-nav__link:hover::after,
+.site-nav__link:focus-visible::after,
+.site-nav__link.is-active::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus-visible,
+.site-nav__link.is-active {
+  color: var(--accent);
+}
+
+.site-nav__link:focus-visible {
+  outline: none;
+  box-shadow: 0 6px 14px -10px rgba(255, 255, 255, 0.7);
+  border-radius: 2px;
 }
 
 .hero {
@@ -209,7 +328,19 @@ body {
   padding: clamp(1.8rem, 4vw, 2.8rem);
   display: grid;
   gap: 1rem;
+  position: relative;
+  overflow: hidden;
   transition: transform var(--transition), border-color var(--transition);
+}
+
+.project::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.05) 30%, rgba(255, 255, 255, 0));
+  transform: translateX(-120%);
+  transition: transform 420ms ease;
+  pointer-events: none;
 }
 
 .project__tag {
@@ -255,6 +386,11 @@ body {
 .project:focus-within {
   transform: translateY(-6px);
   border-color: rgba(255, 255, 255, 0.38);
+}
+
+.project:hover::before,
+.project:focus-within::before {
+  transform: translateX(120%);
 }
 
 .project:hover .project__link::after,
@@ -404,6 +540,26 @@ body {
   }
 }
 
+@keyframes ambientDriftOne {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(60px, -40px, 0) scale(1.08);
+  }
+}
+
+@keyframes ambientDriftTwo {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(-80px, 50px, 0) scale(0.94);
+  }
+}
+
 main {
   display: grid;
   gap: clamp(2rem, 5vw, 4rem);
@@ -419,6 +575,11 @@ main {
 @media (min-width: 900px) {
   body {
     padding: clamp(3rem, 6vw, 6rem);
+  }
+
+  .site-nav {
+    margin-inline: auto;
+    max-width: min(1200px, 100%);
   }
 
   .hero {

--- a/styles.css
+++ b/styles.css
@@ -458,20 +458,68 @@ body {
   letter-spacing: 0.05em;
 }
 
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+.stack-grid {
+  display: grid;
+  gap: 1rem;
 }
 
-.tag {
-  padding: 0.5rem 1.2rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.05);
-  letter-spacing: 0.14em;
+@media (min-width: 640px) {
+  .stack-grid {
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  }
+}
+
+.stack-pill {
+  position: relative;
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  overflow: hidden;
+  transition: transform var(--transition), border-color var(--transition), background var(--transition);
+  isolation: isolate;
+}
+
+.stack-pill::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at 0% 0%, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  opacity: 0;
+  transform: translate3d(-30%, -30%, 0);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  z-index: -1;
+}
+
+.stack-pill:hover,
+.stack-pill:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.36);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.03));
+}
+
+.stack-pill:hover::before,
+.stack-pill:focus-within::before {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.stack-pill__label {
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  font-size: 0.65rem;
+  font-size: 0.62rem;
+  color: var(--text-medium);
+}
+
+.stack-pill__title {
+  font-size: 1.1rem;
+  margin-top: 0.9rem;
+}
+
+.stack-pill__description {
+  margin-top: 0.5rem;
+  color: var(--text-medium);
+  line-height: 1.6;
 }
 
 .footer {

--- a/styles.css
+++ b/styles.css
@@ -45,9 +45,36 @@ body {
     linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 0),
     linear-gradient(0deg, rgba(255, 255, 255, 0.05) 1px, transparent 0);
   background-size: 80px 80px;
+  background-position: center;
   opacity: 0.65;
   z-index: 0;
   animation: gridPulse 12s ease-in-out infinite;
+}
+
+.grid-bg::before,
+.grid-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-repeat: no-repeat;
+  background-size: 80px 80px;
+  mix-blend-mode: screen;
+  opacity: 0;
+  animation-timing-function: ease-in-out;
+  pointer-events: none;
+}
+
+.grid-bg::before {
+  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0) 68%);
+  filter: blur(2px);
+  animation: cellFlashOne 20s infinite;
+}
+
+.grid-bg::after {
+  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 70%);
+  filter: blur(4px);
+  animation: cellFlashTwo 26s infinite;
+  animation-delay: -8s;
 }
 
 .ambient {
@@ -87,6 +114,115 @@ body {
   50% {
     opacity: 0.8;
     transform: scale(1.02);
+  }
+}
+
+@keyframes cellFlashOne {
+  0%,
+  5% {
+    opacity: 0;
+  }
+  6% {
+    opacity: 0.85;
+    background-position: calc(80px * 3) calc(80px * 5);
+  }
+  9% {
+    opacity: 0;
+  }
+  22% {
+    opacity: 0;
+    background-position: calc(80px * 6) calc(80px * 2);
+  }
+  24% {
+    opacity: 0.8;
+  }
+  28% {
+    opacity: 0;
+  }
+  43% {
+    opacity: 0;
+    background-position: calc(80px * 1) calc(80px * 7);
+  }
+  45% {
+    opacity: 0.9;
+  }
+  50% {
+    opacity: 0;
+  }
+  68% {
+    opacity: 0;
+    background-position: calc(80px * 5) calc(80px * 1);
+  }
+  70% {
+    opacity: 0.75;
+  }
+  74% {
+    opacity: 0;
+  }
+  88% {
+    opacity: 0;
+    background-position: calc(80px * 2) calc(80px * 4);
+  }
+  90% {
+    opacity: 0.8;
+  }
+  94%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes cellFlashTwo {
+  0%,
+  8% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.65;
+    background-position: calc(80px * 7) calc(80px * 6);
+  }
+  14% {
+    opacity: 0;
+  }
+  32% {
+    opacity: 0;
+    background-position: calc(80px * 4) calc(80px * 3);
+  }
+  34% {
+    opacity: 0.7;
+  }
+  38% {
+    opacity: 0;
+  }
+  55% {
+    opacity: 0;
+    background-position: calc(80px * 2) calc(80px * 8);
+  }
+  57% {
+    opacity: 0.75;
+  }
+  62% {
+    opacity: 0;
+  }
+  78% {
+    opacity: 0;
+    background-position: calc(80px * 8) calc(80px * 1);
+  }
+  80% {
+    opacity: 0.7;
+  }
+  84% {
+    opacity: 0;
+  }
+  94% {
+    opacity: 0;
+    background-position: calc(80px * 3) calc(80px * 6);
+  }
+  96% {
+    opacity: 0.65;
+  }
+  100% {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a glassmorphism-inspired monochrome portfolio layout with hero, projects, process, and contact sections
- implement smooth animations, responsive grid background, and reusable font utility classes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce8b742530832b90d19989b50fb5d7