### PR TITLE
Create monochrome glassmorphic portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monochrome Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Doto:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <canvas id="asciiCanvas" aria-hidden="true"></canvas>
+  <div class="noise-overlay" aria-hidden="true"></div>
+
+  <header class="hero">
+    <div class="hero__content glass">
+      <p class="hero__tag">Product Designer &amp; Creative Developer</p>
+      <h1>Crafting poetic digital moments in monochrome.</h1>
+      <p class="hero__summary">
+        I am Alex Rivera, a multidisciplinary designer blending code and storytelling to craft immersive, emotionally resonant interfaces.
+      </p>
+      <div class="hero__cta">
+        <a class="btn" href="#projects">View Projects</a>
+        <a class="link" href="#contact">Let&apos;s Collaborate</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="projects" class="section">
+      <div class="section__header">
+        <h2>Selected Projects</h2>
+        <p class="section__subtitle">Each experience is a dialogue between light, shadow, and motion.</p>
+      </div>
+      <div class="grid">
+        <article class="card glass">
+          <h3>Echo Chamber</h3>
+          <p>A spatial audio gallery that translates abstract sculptures into responsive soundscapes.</p>
+          <ul>
+            <li>Immersive 3D audio choreography</li>
+            <li>Dynamic generative visuals</li>
+            <li>Sonic branding toolkit</li>
+          </ul>
+        </article>
+        <article class="card glass">
+          <h3>Lumen Atlas</h3>
+          <p>An interactive atlas that maps human stories through typography and motion.</p>
+          <ul>
+            <li>Custom typographic system</li>
+            <li>Animated storytelling modules</li>
+            <li>Inclusive design framework</li>
+          </ul>
+        </article>
+        <article class="card glass">
+          <h3>Monochrome Futures</h3>
+          <p>A speculative design series exploring the aesthetics of AI empathy.</p>
+          <ul>
+            <li>Ambient sound-driven UI</li>
+            <li>Conversational prototypes</li>
+            <li>Museum-grade visual narrative</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="services" class="section">
+      <div class="section__header">
+        <h2>Services</h2>
+        <p class="section__subtitle">Minimal palettes, maximal emotion.</p>
+      </div>
+      <div class="grid grid--two">
+        <article class="card glass">
+          <h3>Digital Experience Design</h3>
+          <p>Holistic product design across platforms with a focus on accessibility and poetic motion.</p>
+        </article>
+        <article class="card glass">
+          <h3>Creative Coding</h3>
+          <p>Generative installations, interactive narratives, and experimental interfaces that feel alive.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="about" class="section">
+      <div class="section__header">
+        <h2>Approach</h2>
+        <p class="section__subtitle">Balancing intuition, systems, and the unexpected.</p>
+      </div>
+      <div class="timeline">
+        <div class="timeline__item glass">
+          <span class="timeline__year">2024</span>
+          <h3>Principal Product Designer · Helio Labs</h3>
+          <p>Leading cross-disciplinary teams crafting tools that choreograph data into human stories.</p>
+        </div>
+        <div class="timeline__item glass">
+          <span class="timeline__year">2022</span>
+          <h3>Creative Technologist · Studio Umbra</h3>
+          <p>Designed immersive installations blending responsive light, sound, and human gesture.</p>
+        </div>
+        <div class="timeline__item glass">
+          <span class="timeline__year">2019</span>
+          <h3>UX Designer · Northbound</h3>
+          <p>Launched multi-platform products driven by research, clarity, and purposeful simplicity.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer id="contact" class="footer glass">
+    <div class="footer__content">
+      <h2>Let&apos;s build poetic interfaces together.</h2>
+      <p>Email: <a href="mailto:hello@alexrivera.design">hello@alexrivera.design</a></p>
+      <p>Behance · Dribbble · LinkedIn</p>
+    </div>
+    <p class="footer__note">© 2024 Alex Rivera. Crafted in monochrome.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,125 @@
+const canvas = document.getElementById('asciiCanvas');
+const ctx = canvas.getContext('2d');
+const glyphs = ['@', '#', '$', '%', '&', '*', '+', '=', '?', '/', '<', '>', '|', '{', '}'];
+let particles = [];
+let width = 0;
+let height = 0;
+
+const pointer = {
+  x: 0,
+  y: 0,
+  strength: 0,
+};
+
+class AsciiParticle {
+  constructor(initial = false) {
+    this.reset(initial);
+  }
+
+  reset(initial = false) {
+    this.x = Math.random() * width;
+    this.y = initial ? Math.random() * height : -40;
+    this.vx = (Math.random() - 0.5) * 0.25;
+    this.vy = 0.15 + Math.random() * 0.45;
+    this.size = 18 + Math.random() * 18;
+    this.char = glyphs[Math.floor(Math.random() * glyphs.length)];
+    this.alpha = 0.12 + Math.random() * 0.28;
+    this.rotation = (Math.random() - 0.5) * 0.6;
+    this.rotationSpeed = (Math.random() - 0.5) * 0.004;
+    this.switchInterval = 1500 + Math.random() * 3000;
+    this.lastSwitch = performance.now() + Math.random() * this.switchInterval;
+    this.offset = Math.random() * Math.PI * 2;
+  }
+
+  update(now) {
+    this.x += this.vx;
+    this.y += this.vy;
+    this.rotation += this.rotationSpeed;
+
+    if (now - this.lastSwitch > this.switchInterval) {
+      this.char = glyphs[Math.floor(Math.random() * glyphs.length)];
+      this.alpha = 0.12 + Math.random() * 0.28;
+      this.lastSwitch = now + Math.random() * 400;
+    }
+
+    if (pointer.strength > 0.01) {
+      const dx = this.x - pointer.x;
+      const dy = this.y - pointer.y;
+      const distSq = Math.max(dx * dx + dy * dy, 60);
+      const force = (pointer.strength * 1200) / distSq;
+      this.vx += force * dx * 0.02;
+      this.vy += force * dy * 0.02;
+    }
+
+    if (this.y > height + 60) {
+      this.reset();
+      this.y = -40;
+    }
+
+    if (this.x < -60) {
+      this.x = width + 60;
+    } else if (this.x > width + 60) {
+      this.x = -60;
+    }
+  }
+
+  draw(now) {
+    const swayX = Math.cos(now * 0.00025 + this.offset) * 8;
+    const swayY = Math.sin(now * 0.00018 + this.offset) * 6;
+
+    ctx.save();
+    ctx.translate(this.x + swayX, this.y + swayY);
+    ctx.rotate(this.rotation);
+    ctx.globalAlpha = this.alpha;
+    ctx.font = `${this.size}px 'Doto', monospace`;
+    ctx.fillStyle = '#f5f5f5';
+    ctx.shadowColor = 'rgba(255, 255, 255, 0.25)';
+    ctx.shadowBlur = 8;
+    ctx.fillText(this.char, 0, 0);
+    ctx.restore();
+  }
+}
+
+function resize() {
+  width = window.innerWidth;
+  height = window.innerHeight;
+  canvas.width = width;
+  canvas.height = height;
+
+  const density = 0.00018;
+  const desired = Math.max(80, Math.floor(width * height * density));
+  particles = particles.slice(0, desired);
+  while (particles.length < desired) {
+    particles.push(new AsciiParticle(true));
+  }
+}
+
+function animate(now) {
+  ctx.fillStyle = 'rgba(5, 5, 5, 0.32)';
+  ctx.fillRect(0, 0, width, height);
+
+  for (const particle of particles) {
+    particle.update(now);
+    particle.draw(now);
+  }
+
+  pointer.strength *= 0.92;
+  requestAnimationFrame(animate);
+}
+
+window.addEventListener('resize', () => {
+  resize();
+});
+
+window.addEventListener('pointermove', (event) => {
+  pointer.x = event.clientX;
+  pointer.y = event.clientY;
+  pointer.strength = Math.min(pointer.strength + 0.4, 1);
+});
+
+window.addEventListener('pointerleave', () => {
+  pointer.strength = 0;
+});
+
+resize();
+requestAnimationFrame(animate);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,244 @@
+:root {
+  color-scheme: dark;
+  --bg: #050505;
+  --fg: #f7f7f7;
+  --muted: rgba(255, 255, 255, 0.65);
+  --glass: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Doto', sans-serif;
+  background: radial-gradient(circle at top, #0f0f0f, var(--bg));
+  color: var(--fg);
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+a {
+  color: inherit;
+}
+
+canvas#asciiCanvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -2;
+  mix-blend-mode: screen;
+}
+
+.noise-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"%3E%3Cfilter id="n" x="0" y="0" width="100%25" height="100%25"%3E%3CfeTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" stitchTiles="stitch"/%3E%3C/filter%3E%3Crect width="100" height="100" filter="url(%23n)" opacity="0.12"/%3E%3C/svg%3E');
+  opacity: 0.45;
+}
+
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8rem 1.5rem 6rem;
+}
+
+.hero__content {
+  max-width: 760px;
+  padding: 3.5rem;
+  display: grid;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.hero__tag {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  margin: 1rem 0;
+  line-height: 1.1;
+}
+
+.hero__summary {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero__cta {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.btn {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.7));
+  color: #090909;
+  padding: 0.85rem 2.25rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.btn:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.link {
+  text-decoration: none;
+  color: var(--fg);
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  transition: border 0.3s ease, transform 0.3s ease;
+}
+
+.link:hover {
+  border-color: rgba(255, 255, 255, 0.55);
+  transform: translateY(-2px);
+}
+
+main {
+  padding: 0 1.5rem 6rem;
+}
+
+.section {
+  max-width: 1100px;
+  margin: 0 auto 6rem;
+}
+
+.section__header {
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.section__subtitle {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.4s ease, border 0.4s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline__item {
+  padding: 2rem 2.5rem;
+  position: relative;
+}
+
+.timeline__year {
+  font-size: 0.9rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.footer {
+  margin: 0 auto 4rem;
+  max-width: 900px;
+  padding: 3rem 2.5rem;
+  text-align: center;
+}
+
+.footer__content {
+  display: grid;
+  gap: 1rem;
+}
+
+.footer a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.footer a:hover {
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.footer__note {
+  margin-top: 2rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+}
+
+.glass {
+  background: var(--glass);
+  border: 1px solid var(--border);
+  border-radius: 32px;
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 720px) {
+  .hero__content {
+    padding: 2.5rem 2rem;
+  }
+
+  .card {
+    padding: 2rem 1.75rem;
+  }
+
+  .timeline__item {
+    padding: 1.75rem 2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page portfolio layout with hero, projects, services, and contact sections
- implement glassmorphism-inspired styling and Doto typography in a monochrome palette
- animate an ASCII background canvas with drifting glyphs and pointer interaction for ambience

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce995276a8832b81b511d71cdf66f1